### PR TITLE
Adds rust syntax highlight and highligts cucumber strings

### DIFF
--- a/after/syntax/cucumber.vim
+++ b/after/syntax/cucumber.vim
@@ -1,0 +1,7 @@
+syn region cucumberGivenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberGivenRegion,cucumberGivenAndRegion,cucumberGivenButRegion
+syn region cucumberWhenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberWhenRegion,cucumberWhenAndRegion,cucumberWhenButRegion
+syn region cucumberThenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberThenRegion,cucumberThenAndRegion,cucumberThenButRegion
+
+hi def link cucumberGivenString cucumberString
+hi def link cucumberWhenString cucumberString
+hi def link cucumberThenString cucumberString

--- a/after/syntax/cucumber.vim
+++ b/after/syntax/cucumber.vim
@@ -1,7 +1,0 @@
-syn region cucumberGivenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberGivenRegion,cucumberGivenAndRegion,cucumberGivenButRegion
-syn region cucumberWhenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberWhenRegion,cucumberWhenAndRegion,cucumberWhenButRegion
-syn region cucumberThenString start=/"/ skip=/\\"/ end=/"/ contained containedin=cucumberThenRegion,cucumberThenAndRegion,cucumberThenButRegion
-
-hi def link cucumberGivenString cucumberString
-hi def link cucumberWhenString cucumberString
-hi def link cucumberThenString cucumberString

--- a/bundles.vim
+++ b/bundles.vim
@@ -92,13 +92,12 @@ Bundle 'puppetlabs/puppet-syntax-vim'
 Bundle 'elzr/vim-json'
 Bundle 'hail2u/vim-css3-syntax'
 Bundle 'elixir-lang/vim-elixir'
+Plugin 'rust-lang/rust.vim'
 Bundle 'barboza/vim-cucumber-string-highlight'
 " Javascript syntax
 Bundle 'rschmukler/pangloss-vim-indent'
 Bundle 'othree/yajs.vim'
 Bundle 'mxw/vim-jsx', { 'rtp': 'after/' }
-" Rust syntax
-Plugin 'rust-lang/rust.vim'
 "--------------------------
 " color scheme
 "--------------------------

--- a/bundles.vim
+++ b/bundles.vim
@@ -96,7 +96,8 @@ Bundle 'elixir-lang/vim-elixir'
 Bundle 'rschmukler/pangloss-vim-indent'
 Bundle 'othree/yajs.vim'
 Bundle 'mxw/vim-jsx', { 'rtp': 'after/' }
-
+" Rust syntax
+Plugin 'rust-lang/rust.vim'
 "--------------------------
 " color scheme
 "--------------------------

--- a/bundles.vim
+++ b/bundles.vim
@@ -92,6 +92,7 @@ Bundle 'puppetlabs/puppet-syntax-vim'
 Bundle 'elzr/vim-json'
 Bundle 'hail2u/vim-css3-syntax'
 Bundle 'elixir-lang/vim-elixir'
+Bundle 'barboza/vim-cucumber-string-highlight'
 " Javascript syntax
 Bundle 'rschmukler/pangloss-vim-indent'
 Bundle 'othree/yajs.vim'


### PR DESCRIPTION
String in cucumber scenarios were using the same color as the rest of the steps. Using the after/syntax/cucumber.vim we can override the default cucumber syntax highlight to change the color of strings.

Taken from http://spin.atomicobject.com/2012/01/22/highlight-cucumber-strings-in-vim/